### PR TITLE
supported ProxyJump

### DIFF
--- a/sshc.go
+++ b/sshc.go
@@ -2,12 +2,14 @@
 package sshc
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,6 +173,16 @@ func (c *Config) DialWithConfig() (*ssh.Client, error) {
 	}
 
 	proxyCommand := c.Get(host, "ProxyCommand")
+	proxyJump := c.Get(host, "ProxyJump")
+
+	if proxyJump != "" {
+		parsedProxyJump, err := c.parseProxyJump(proxyJump)
+		if err != nil {
+			return nil, err
+		}
+		proxyCommand = parsedProxyJump
+	}
+
 	if proxyCommand != "" {
 		client, server := net.Pipe()
 		proxyCommand = c.unescapeCharacters(proxyCommand)
@@ -249,4 +261,23 @@ func newSSHAgentClient() (agent.ExtendedAgent, error) {
 
 func sshAuthSockExists() bool {
 	return os.Getenv("SSH_AUTH_SOCK") != ""
+}
+
+func (c *Config) parseProxyJump(text string) (string, error) {
+	proxyPort := "22"
+	if strings.Contains(text, ":") {
+		var portReg = regexp.MustCompile(`.+:(?P<port>[0-9]+)`)
+		match := portReg.FindAllStringSubmatch(text, -1)
+		if len(match) == 0 {
+			return "", errors.New("proxyJump is wrong format")
+		}
+
+		for i, name := range portReg.SubexpNames() {
+			if i != 0 && name == "port" {
+				proxyPort = match[0][i]
+			}
+		}
+		text = text[:strings.Index(text, ":")]
+	}
+	return fmt.Sprintf("ssh -l %%r -W %%h:%%p  %s -p %s", c.unescapeCharacters(text), proxyPort), nil
 }

--- a/sshc_test.go
+++ b/sshc_test.go
@@ -100,3 +100,49 @@ func TestGet(t *testing.T) {
 		t.Fatalf("want = %#v, got = %#v", want, got)
 	}
 }
+
+func TestConfig_parseProxyJump(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "full config",
+			text:    "user@host:2002",
+			want:    "ssh -l %r -W %h:%p  user@host -p 2002",
+			wantErr: false,
+		},
+		{
+			name:    "not defined port",
+			text:    "user@host",
+			want:    "ssh -l %r -W %h:%p  user@host -p 22",
+			wantErr: false,
+		},
+		{
+			name:    "not defined user",
+			text:    "host:2222",
+			want:    "ssh -l %r -W %h:%p  host -p 2222",
+			wantErr: false,
+		},
+		{
+			name:    "wrong port format",
+			text:    "user@host:xxxxx",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := NewConfig("example.com")
+			got, err := c.parseProxyJump(tt.text)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.parseProxyJump() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Config.parseProxyJump() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
refs: https://man.openbsd.org/ssh_config.5

sshd_configのmanによれば、ProxyJumpは `[user@]host[:port]` のフォーマットらしいので、ProxyJumpの定義からProxyCommandを生成することで、既存の処理を活かしつつ、ProxyJumpをサポートするというアイディアです。